### PR TITLE
Fix an issue in windows by using utf-8 encoding to write the vtt file

### DIFF
--- a/yt_whisper/cli.py
+++ b/yt_whisper/cli.py
@@ -41,7 +41,7 @@ def main():
         warnings.filterwarnings("default")
 
         vtt_path = os.path.join(output_dir, f"{slugify(title)}.vtt")
-        with open(vtt_path, 'w') as vtt:
+        with open(vtt_path, 'w', encoding="utf-8") as vtt:
             write_vtt(result["segments"], file=vtt)
 
         # print saved message with absolute path


### PR DESCRIPTION
The CLI is throwing the following error (on windows, using the video [https://www.youtube.com/watch?v=_MJRecWakxw](https://www.youtube.com/watch?v=_MJRecWakxw), and using the  model "medium.en"):

```
Downloaded video "Rick Astley - Never Gonna Give You Up (Official Music Video)". Generating subtitles...
Traceback (most recent call last):
  File "C:\Users\usuario\AppData\Local\Programs\Python\Python310\Scripts\yt_whisper-script.py", line 33, in <module>
    sys.exit(load_entry_point('yt-whisper', 'console_scripts', 'yt_whisper')())
  File "d:\documentos\programacion\ai\whisper\yt-whisper\yt_whisper\cli.py", line 45, in main
    write_vtt(result["segments"], file=vtt)
  File "d:\documentos\programacion\ai\whisper\yt-whisper\yt_whisper\utils.py", line 32, in write_vtt
    print(
  File "C:\Users\usuario\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f3b5' in position 26: character maps to <undefined>
```

![image](https://user-images.githubusercontent.com/16585568/192159928-d814dee7-0e0b-42da-9ec8-2116133685d7.png)

The error is because of the character \U0001f3b5 (this emoji: 🎵)
Apparently the encoding that windows chooses in my computer (cp1252) is not compatible with emojis.

This pull request fixes the error by explicitly using "encoding="utf-8" to write the VTT file.

After the fix the subtitles are generated with no problems:
![image](https://user-images.githubusercontent.com/16585568/192159984-509f364a-e825-4487-8152-9886beb55363.png)
