### PR TITLE
feat: manual device selection

### DIFF
--- a/yt_whisper/cli.py
+++ b/yt_whisper/cli.py
@@ -21,10 +21,12 @@ def main():
 
     parser.add_argument("--task", type=str, default="transcribe", choices=[
                         "transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")
+    parser.add_argument("--device", choices=("cpu", "cuda"), help="device to use for PyTorch inference")
 
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")
     output_dir: str = args.pop("output_dir")
+    device: str = args.pop("device")
     os.makedirs(output_dir, exist_ok=True)
 
     if model_name.endswith(".en"):
@@ -32,7 +34,7 @@ def main():
             f"{model_name} is an English-only model, forcing English detection.")
         args["language"] = "en"
 
-    model = whisper.load_model(model_name)
+    model = whisper.load_model(model_name, device=device)
     audios = get_audio(args.pop("video"))
 
     for title, audio_path in audios.items():


### PR DESCRIPTION
Closes #11

chocies: `cuda`, `cpu`

```bash
yt_whisper "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --device cpu
yt_whisper "https://www.youtube.com/watch?v=dQw4w9WgXcQ" --device cuda
```

If `--device` is not provided, default will be cuda if available else cpu (as implemented in the whisper model).