### PR TITLE
feat: add option to break long lines into two

### DIFF
--- a/yt_whisper/cli.py
+++ b/yt_whisper/cli.py
@@ -22,6 +22,9 @@ def main():
     parser.add_argument("--task", type=str, default="transcribe", choices=[
                         "transcribe", "translate"], help="whether to perform X->X speech recognition ('transcribe') or X->English translation ('translate')")
 
+    parser.add_argument("--break-lines", type=int, default=0, 
+                        help="Whether to break lines into a bottom-heavy pyramid shape if line length exceeds N characters. 0 disables line breaking.")
+
     args = parser.parse_args().__dict__
     model_name: str = args.pop("model")
     output_dir: str = args.pop("output_dir")
@@ -34,6 +37,7 @@ def main():
 
     model = whisper.load_model(model_name)
     audios = get_audio(args.pop("video"))
+    break_lines = args.pop("break_lines")
 
     for title, audio_path in audios.items():
         warnings.filterwarnings("ignore")
@@ -42,7 +46,7 @@ def main():
 
         vtt_path = os.path.join(output_dir, f"{slugify(title)}.vtt")
         with open(vtt_path, 'w', encoding="utf-8") as vtt:
-            write_vtt(result["segments"], file=vtt)
+            write_vtt(result["segments"], file=vtt, line_length=break_lines)
 
         # print saved message with absolute path
         print("Saved VTT to", os.path.abspath(vtt_path))

--- a/yt_whisper/cli.py
+++ b/yt_whisper/cli.py
@@ -58,7 +58,7 @@ def main():
         else:
             srt_path = os.path.join(output_dir, f"{slugify(title)}.srt")
             with open(srt_path, 'w', encoding="utf-8") as srt:
-                write_srt(result["segments"], file=srt)
+                write_srt(result["segments"], file=srt, line_length=break_lines)
 
             print("Saved SRT to", os.path.abspath(srt_path))
 

--- a/yt_whisper/utils.py
+++ b/yt_whisper/utils.py
@@ -42,13 +42,18 @@ def break_line(line: str, length: int):
     else:
         return line
 
+def process_segment(segment: dict, line_length: int = 0):
+    segment["text"] = segment["text"].strip()
+    if line_length > 0 and len(segment["text"]) > line_length:
+        # break at N characters as per Netflix guidelines
+        segment["text"] = break_line(segment["text"], line_length)
+    
+    return segment
 
 def write_vtt(transcript: Iterator[dict], file: TextIO, line_length: int = 0):
     print("WEBVTT\n", file=file)
     for segment in transcript:
-        if line_length > 0 and len(segment["text"]) > line_length:
-            # break at N characters as per Netflix guidelines
-            segment["text"] = break_line(segment["text"], line_length)
+        segment = process_segment(segment, line_length=line_length)
 
         print(
             f"{format_timestamp(segment['start'])} --> {format_timestamp(segment['end'])}\n"
@@ -58,8 +63,10 @@ def write_vtt(transcript: Iterator[dict], file: TextIO, line_length: int = 0):
         )
 
 
-def write_srt(transcript: Iterator[dict], file: TextIO):
+def write_srt(transcript: Iterator[dict], file: TextIO, line_length: int = 0):
     for i, segment in enumerate(transcript, start=1):
+        segment = process_segment(segment, line_length=line_length)
+
         print(
             f"{i}\n"
             f"{format_timestamp(segment['start'], always_include_hours=True, decimal_marker=',')} --> "


### PR DESCRIPTION
Closes #1

Sorry for taking so long! The problem turned out to be a little more (or less) complicated than I thought.

The approach I take here is to get the middle of the string (so that the lines are roughly even) and decrement that slice until it hits a space. This works well but makes some choices I'll list in case you want to change them:
- lines are only broken into _two_ lines, rather than three (Netflix has a maximum of three)
- the end of the first line doesn't include a space, but it keeps the space at the beginning of the line (Whisper generates these,)
- break length is configurable by the `--break-lines N` option. A single flag made sense to me, but if you'd rather have `--break-lines` and `--line-length`, I'm open to that.