### PR TITLE
transcribe local files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 yt-dlp
 git+https://github.com/openai/whisper.git
+validators


### PR DESCRIPTION
Fixed #25 . Just pass a directory path where you previously passed YouTube URLs, and the CLI will transcribe it. For now the output file name is the same as the entire directory. I leave naming the file to just the name of the video file as an exercise for later.